### PR TITLE
Sanitize Database Cleaner

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.strategy = :truncation, { :except => %w[public.schema_migrations]}
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
The latest version of the Database Cleaner gem will wipe away the `schema_migrations` table from your database. This causes the next db migration to break, because the migration task tries to duplicate old migrations from the very beginning. Read more [here](https://github.com/DatabaseCleaner/database_cleaner/issues/317)
